### PR TITLE
重构wrapper以使用lua的gc和metatable系统，修改命名规范

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 0

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # cold clear ai love2d wrapper
 [![CI](https://github.com/26F-Studio/cold_clear_ai_love2d_wrapper/workflows/CI/badge.svg)](https://github.com/26F-Studio/cold_clear_ai_love2d_wrapper/actions)
-![platform](https://img.shields.io/badge/platform-windows%20%7C%20linux%20%7C%20android-brightgreen.svg)
+![platform](https://img.shields.io/badge/platform-windows%20%7C%20linux%20%7C%20android%20%7C%20macos-brightgreen.svg)
 
 This is a love2d/lua wrapper for [cold clear](https://github.com/MinusKelvin/cold-clear), in order use it in tetris games made by [love2d game engine](https://love2d.org/).
 
@@ -16,7 +16,7 @@ typedef enum CCPiece {
 ```
 
 However, for *tech*nical reasons (pun intended!), the wrapper uses a reversed order,
-i.e. Z S J L T O I.
+i.e. `Z S J L T O I`.
 
 ### Error messages
 
@@ -48,54 +48,8 @@ love.filesystem.write("libCCloader.so", love.filesystem.read("libCCloader.so"))
 require "CCloader"
 ```
 
-### Have trouble in building cold clear?
-You can get it from [here](https://github.com/flaribbit/cold-clear/actions).
-
 ## How to use
-```lua
-require "cold_clear_wrapper"
-
--- get default options and weights
-options, weights=cc.get_default_config()
-
--- maybe try optional fast game config weights
-cc.fast_weights(weights)
-
--- or change some weights
-cc.set_weights(weights, {key1=val1, key2=val2, ...})
-
--- also you can change some options (bool)
-cc.set_options(options, _hold, _20g, _bag7)
-
--- create new bot
-bot = cc.launch_async(options, weights)
-
--- refresh current status and field
--- field is a table contains 400 bools
-cc.reset_async(bot, field, b2b, combo)
-
--- add next piece
-cc.add_next_piece_async(bot, piece)
-
--- calculate next move
-cc.request_next_move(bot, jeopardy)
-
--- or without jeopardy
-cc.request_next_move(bot)
-
--- get next move
--- cc_is_dead_async now in status
-status, hold, move = cc.poll_next_move(bot)
--- or blocking version
-status, hold, move = cc.block_next_move(bot)
-
--- destroy
-cc.destroy_async(bot)
-
--- remember to free there pointers
-cc.free(options)
-cc.free(weights)
-```
+See `cc.lua`
 
 Some important information from coldclear.h
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,24 @@
 
 This is a love2d/lua wrapper for [cold clear](https://github.com/MinusKelvin/cold-clear), in order use it in tetris games made by [love2d game engine](https://love2d.org/).
 
+## Pitfalls
+
+### Piece id
+
+In the code of cold clear, the pieces are represented as integer thus:
+```c
+typedef enum CCPiece {
+    CC_I, CC_O, CC_T, CC_L, CC_J, CC_S, CC_Z
+} CCPiece;
+```
+
+However, for *tech*nical reasons (pun intended!), the wrapper uses a reversed order,
+i.e. Z S J L T O I.
+
+### Error messages
+
+The whole API segfaults on any type errors. To see sensible error messages and stack traces, uncomment the `#define DEBUG_CC` macro in `cold_clear_wrapper.c`.
+
 ## How to build
 `git clone https://github.com/26F-Studio/cold_clear_ai_love2d_wrapper --recursive`
 ### windows
@@ -87,10 +105,6 @@ typedef enum CCBotPollStatus {
     CC_WAITING,
     CC_BOT_DEAD
 } CCBotPollStatus;
-
-typedef enum CCPiece {
-    CC_I, CC_O, CC_T, CC_L, CC_J, CC_S, CC_Z
-} CCPiece;
 
 typedef enum CCMovement {
     CC_LEFT, CC_RIGHT,

--- a/cc.lua
+++ b/cc.lua
@@ -11,18 +11,18 @@ local CCBot = {}
 
 ---@return CCOptions
 ---@return CCWeights
-function cc.get_default_config() end
+function cc.getDefaultConfig() end
 
 ---@param weights CCWeights
-function cc.default_weights(weights) end
+function cc.defaultWeights(weights) end
 
 ---@param options CCOptions
-function cc.default_options(options) end
+function cc.defaultOptions(options) end
 
 ---@param options CCOptions
 ---@param weights CCWeights
 ---@return CCBot
-function cc.launch_async(options, weights) end
+function cc.launchAsync(options, weights) end
 
 ---@return string
 function cc.about() end

--- a/cc.lua
+++ b/cc.lua
@@ -1,0 +1,81 @@
+---@meta
+---@class cc
+local cc = {}
+---@class CCOptions
+local CCOptions = {}
+---@class CCWeights
+local CCWeights = {}
+---@class CCBot
+local CCBot = {}
+
+
+---@return CCOptions
+---@return CCWeights
+function cc.get_default_config() end
+
+---@param weights CCWeights
+function cc.default_weights(weights) end
+
+---@param options CCOptions
+function cc.default_options(options) end
+
+---@param options CCOptions
+---@param weights CCWeights
+---@return CCBot
+function cc.launch_async(options, weights) end
+
+---@return string
+function cc.about() end
+
+
+---@param bot CCBot
+---@param field boolean[]
+---@param b2b boolean
+---@param combo integer
+function CCBot:update(bot, field, b2b, combo) end
+
+---@param piece integer
+function CCBot:addNext(piece) end
+
+---@param incoming? integer
+function CCBot:think(incoming) end
+
+---@return integer status
+---@return boolean hold
+---@return integer[] move
+function CCBot:getMove() end
+
+---@return integer status
+---@return boolean hold
+---@return integer[] move
+function CCBot:blockNextMove() end
+
+
+---@param canhold boolean
+---@param is20g boolean
+---@param isbag7 boolean
+function CCOptions:setOptions(canhold, is20g, isbag7) end
+
+---@param canhold boolean
+function CCOptions:setHold(canhold) end
+
+---@param is20g boolean
+function CCOptions:set20G(is20g) end
+
+---@param isbag7 boolean
+function CCOptions:setBag(isbag7) end
+
+---@param ispcloop boolean
+function CCOptions:setPCLoop(ispcloop) end
+
+---@param nodes integer
+function CCOptions:setNode(nodes) end
+
+
+---@param key string
+---@param value number
+function CCWeights:setWeights(key, value) end
+
+function CCWeights:fastWeights() end
+
+return cc

--- a/cc.lua
+++ b/cc.lua
@@ -13,12 +13,6 @@ local CCBot = {}
 ---@return CCWeights
 function cc.getDefaultConfig() end
 
----@param weights CCWeights
-function cc.defaultWeights(weights) end
-
----@param options CCOptions
-function cc.defaultOptions(options) end
-
 ---@param options CCOptions
 ---@param weights CCWeights
 ---@return CCBot
@@ -51,6 +45,8 @@ function CCBot:getMove() end
 function CCBot:blockNextMove() end
 
 
+function CCOptions.defaultOptions() end
+
 ---@param canhold boolean
 ---@param is20g boolean
 ---@param isbag7 boolean
@@ -71,6 +67,8 @@ function CCOptions:setPCLoop(ispcloop) end
 ---@param nodes integer
 function CCOptions:setNode(nodes) end
 
+
+function CCWeights:defaultWeights() end
 
 ---@param key string
 ---@param value number

--- a/cold_clear_wrapper.c
+++ b/cold_clear_wrapper.c
@@ -7,7 +7,7 @@
 #include "lua.h"
 #include "lualib.h"
 
-// #define DEBUG_CC
+#define DEBUG_CC
 #ifdef DEBUG_CC
 static void *check_userdata(lua_State *L, int index, const char *tname) {
     void *ud = luaL_checkudata(L, index, tname);
@@ -40,8 +40,8 @@ static int launch_async(lua_State *L) {
 
 //void cc_destroy_async(CCAsyncBot *bot);
 static int destroy_async(lua_State *L) {
-    CCAsyncBot **bot = (CCAsyncBot **)check_userdata(L, 1, "CCBot");
-    cc_destroy_async(*bot);
+    CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
+    cc_destroy_async(bot);
     return 0;
 }
 
@@ -52,12 +52,12 @@ static int reset_async(lua_State *L) {
     int combo = lua_tointeger(L, 4);
     bool field[400];
     int size = luaL_getn(L, 2);
-    for (int i = 1; i <= size; i++) {
+    int i;
+    for (i = 1; i <= size; i++) {
         lua_rawgeti(L, 2, i);
-        field[i] = lua_toboolean(L, -1);
+        field[i-1] = lua_toboolean(L, -1);
         lua_pop(L, 1);
     }
-    /* Should we check for whether i==400 ? */
     cc_reset_async(bot, field, b2b, combo);
     return 0;
 }

--- a/cold_clear_wrapper.c
+++ b/cold_clear_wrapper.c
@@ -7,25 +7,47 @@
 #include "lua.h"
 #include "lualib.h"
 
+// #define DEBUG_CC
+#ifdef DEBUG_CC
+static void* check_userdata(lua_State *L, int index, const char *tname) {
+    void *ud = luaL_checkudata(L, index, tname);
+    luaL_argcheck(L, ud != NULL, index, tname);
+    return ud;
+}
+#define lua_tointeger luaL_checkinteger
+#define lua_tostring luaL_checkstring
+#define lua_tonumber luaL_checknumber
+#else  /* DEBUG_CC */
+static void* check_userdata(lua_State *L, int index, const char *tname) {
+    return lua_touserdata(L, index);
+}
+#endif  /* DEBUG_CC */
+
 //CCAsyncBot *cc_launch_async(CCOptions *options, CCWeights *weights);
 static int launch_async(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
-    CCWeights *weights = (CCWeights *)lua_touserdata(L, 2);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
+    CCWeights *weights = (CCWeights *)check_userdata(L, 2, "CCWeights");
     CCAsyncBot *bot = cc_launch_async(options, weights, 0, 0, 0);
-    lua_pushlightuserdata(L, (void *)bot);
+    CCAsyncBot **botdata = (CCAsyncBot **)lua_newuserdata(L, sizeof(CCAsyncBot *));
+    /* evil double pointers appear because the cc API gives us a pointer,
+       and don't provide the chance for lua to allocate memory itself.
+       See https://www.lua.org/pil/28.1.html#:~:text=If%20for%20some%20reason%20you%20need%20to%20allocate%20memory%20by%20other%20means%2C%20it%20is%20very%20easy%20to%20create%20a%20userdatum%20with%20the%20size%20of%20a%20pointer%20and%20to%20store%20there%20a%20pointer%20to%20the%20real%20memory%20block.%20We%20will%20see%20examples%20of%20this%20technique%20in%20the%20next%20chapter. */
+    *botdata = bot;
+    luaL_getmetatable(L, "CCBot");
+    lua_setmetatable(L, -2);
     return 1;
 }
 
 //void cc_destroy_async(CCAsyncBot *bot);
 static int destroy_async(lua_State *L) {
-    CCAsyncBot *bot = (CCAsyncBot *)lua_touserdata(L, 1);
-    cc_destroy_async(bot);
+    CCAsyncBot **bot = (CCAsyncBot **)check_userdata(L, 1, "CCBot");
+    cc_destroy_async(*bot);
     return 0;
 }
 
 //void cc_reset_async(CCAsyncBot *bot, bool *field, bool b2b, uint32_t combo);
 static int reset_async(lua_State *L) {
-    CCAsyncBot *bot = (CCAsyncBot *)lua_touserdata(L, 1);
+    CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
     bool b2b = lua_toboolean(L, 3);
     int combo = lua_tointeger(L, 4);
     bool field[400];
@@ -42,15 +64,15 @@ static int reset_async(lua_State *L) {
 
 //void cc_add_next_piece_async(CCAsyncBot *bot, CCPiece piece);
 static int add_next_piece_async(lua_State *L) {
-    CCAsyncBot *bot = (CCAsyncBot *)lua_touserdata(L, 1);
+    CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
     int piece = lua_tointeger(L, 2);
-    cc_add_next_piece_async(bot, piece);
+    cc_add_next_piece_async(bot, 7-piece);
     return 0;
 }
 
 //void cc_request_next_move(CCAsyncBot *bot, uint32_t incoming);
 static int request_next_move(lua_State *L) {
-    CCAsyncBot *bot = (CCAsyncBot *)lua_touserdata(L, 1);
+    CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
     if (lua_isnumber(L, 2)) {
         cc_request_next_move(bot, lua_tointeger(L, 2));
     } else {
@@ -100,7 +122,7 @@ int return_cc_move(lua_State *L, CCBotPollStatus ret, CCMove *move, CCPlanPlacem
 //    uint32_t *plan_length
 //);
 static int poll_next_move(lua_State *L) {
-    CCAsyncBot *bot = (CCAsyncBot *)lua_touserdata(L, 1);
+    CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
     CCMove move;
     CCBotPollStatus ret = cc_poll_next_move(bot, &move, NULL, NULL);
     return return_cc_move(L, ret, &move, NULL, NULL);
@@ -113,7 +135,7 @@ static int poll_next_move(lua_State *L) {
 //    uint32_t *plan_length
 //);
 static int block_next_move(lua_State *L) {
-    CCAsyncBot *bot = (CCAsyncBot *)lua_touserdata(L, 1);
+    CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
     CCMove move;
     CCBotPollStatus ret = cc_block_next_move(bot, &move, NULL, NULL);
     return return_cc_move(L, ret, &move, NULL, NULL);
@@ -121,43 +143,46 @@ static int block_next_move(lua_State *L) {
 
 //void cc_default_options(CCOptions *options);
 static int default_options(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     cc_default_options(options);
     return 0;
 }
 
 //void cc_default_weights(CCWeights *weights);
 static int default_weights(lua_State *L) {
-    CCWeights *weights = (CCWeights *)lua_touserdata(L, 1);
+    CCWeights *weights = (CCWeights *)check_userdata(L, 1, "CCWeights");
     cc_default_weights(weights);
     return 0;
 }
 
 //void cc_fast_weights(CCWeights *weights);
 static int fast_weights(lua_State *L) {
-    CCWeights *weights = (CCWeights *)lua_touserdata(L, 1);
+    CCWeights *weights = (CCWeights *)check_userdata(L, 1, "CCWeights");
     cc_fast_weights(weights);
     return 0;
 }
 
 //供lua创建新的默认选项数据
 static int get_default_config(lua_State *L) {
-    CCOptions *options = (CCOptions *)malloc(sizeof(CCOptions));
-    CCWeights *weights = (CCWeights *)malloc(sizeof(CCWeights));
+    CCOptions *options = (CCOptions *)lua_newuserdata(L, sizeof(CCOptions));
+    luaL_getmetatable(L, "CCOptions");
+    lua_setmetatable(L, -2);
+    CCWeights *weights = (CCWeights *)lua_newuserdata(L, sizeof(CCWeights));
+    luaL_getmetatable(L, "CCWeights");
+    lua_setmetatable(L, -2);
     cc_default_options(options);
     // Not the same with techmino, but suits better
     // note that rows in cold clear is 0-indexed
     // maybe it should be settable
     options->spawn_rule = CC_ROW_21_AND_FALL;
     cc_default_weights(weights);
-    lua_pushlightuserdata(L, (void *)options);
-    lua_pushlightuserdata(L, (void *)weights);
     return 2;
 }
 
 //供lua调用的hold 20g bag7 pcf设置
+// options:set_options(hold, 20g, bag7, pcloop)
 static int set_options(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     bool hold = lua_toboolean(L, 2);
     bool _20g = lua_toboolean(L, 3);
     bool bag7 = lua_toboolean(L, 4);
@@ -169,63 +194,65 @@ static int set_options(lua_State *L) {
     return 0;
 }
 
+// options:set_hold(hold)
 static int set_hold(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     bool hold = lua_toboolean(L, 2);
     options->use_hold = hold;
     return 0;
 }
 
+// options:set_20g(20g)
 static int set_20g(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     bool _20g = lua_toboolean(L, 2);
     options->mode = _20g;
     return 0;
 }
 
+// options:set_bag7(bag7)
 static int set_bag7(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     bool bag7 = lua_toboolean(L, 2);
     options->speculate = bag7;
     return 0;
 }
 
+// options:set_pcloop(pcloop)
 static int set_pcloop(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     bool pcloop = lua_toboolean(L, 2);
     options->pcloop = pcloop;
     return 0;
 }
 
+// options:set_min_nodes(min_nodes)
 static int set_min_nodes(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     int min_nodes = lua_tointeger(L, 2);
     options->min_nodes = min_nodes;
     return 0;
 }
 
+// options:set_max_nodes(max_nodes)
 static int set_max_nodes(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     int max_nodes = lua_tointeger(L, 2);
     options->max_nodes = max_nodes;
     return 0;
 }
 
+// options:set_threads(threads)
 static int set_threads(lua_State *L) {
-    CCOptions *options = (CCOptions *)lua_touserdata(L, 1);
+    CCOptions *options = (CCOptions *)check_userdata(L, 1, "CCOptions");
     int threads = lua_tointeger(L, 2);
     options->threads = threads;
     return 0;
 }
 
-static int cfree(lua_State *L) {
-    void *p = lua_touserdata(L, 1);
-    free(p);
-    return 0;
-}
-
+// weights:set_weights(weights table)
 static int set_weights(lua_State *L) {
-    CCWeights *weights = (CCWeights *)lua_touserdata(L, 1);
+    CCWeights *weights = (CCWeights *)check_userdata(L, 1, "CCWeights");
     while (lua_next(L, 2)) {
         const char *key = lua_tostring(L, -2);
         int value = lua_tonumber(L, -1);
@@ -261,7 +288,7 @@ static int set_weights(lua_State *L) {
         else if(!strcmp(key,"move_time"))        weights->move_time=value;
         else if(!strcmp(key,"wasted_t"))         weights->wasted_t=value;
         // clang-format on
-        lua_pop(L, 1);
+        lua_pop(L, 2);
     }
     return 0;
 }
@@ -271,30 +298,57 @@ static int about(lua_State *L) {
     return 1;
 }
 
+/* TODO: Revise the naming convention. These strings should really be named as in lua
+Changing these is as easy as a Find+Replace, so I'm not deciding for now. */
 static const struct luaL_Reg funcList[] = {
     {"about", about},
-    {"launch_async", launch_async},
-    {"destroy_async", destroy_async},
-    {"reset_async", reset_async},
-    {"add_next_piece_async", add_next_piece_async},
-    {"request_next_move", request_next_move},
-    {"poll_next_move", poll_next_move},
-    {"block_next_move", block_next_move},
-    {"default_options", default_options},
-    {"default_weights", default_weights},
-    {"fast_weights", fast_weights},
-    {"get_default_config", get_default_config},
-    {"set_options", set_options},
-    {"set_hold", set_hold},
-    {"set_20g", set_20g},
-    {"set_bag7", set_bag7},
-    {"set_pcloop", set_pcloop},
-    {"set_max_nodes", set_max_nodes},
-    {"set_weights", set_weights},
-    {"free", cfree},
+    {"launchAsync", launch_async},
+    {"defaultOptions", default_options},
+    {"defaultWeights", default_weights},
+    {"getDefaultConfig", get_default_config},
+    {0, 0}};
+
+static const struct luaL_Reg methList[] = {
+    {"__gc", destroy_async},
+    {"update", reset_async},
+    {"addNext", add_next_piece_async},
+    {"think", request_next_move},
+    {"getMove", poll_next_move},
+    {"blockNextMove", block_next_move},
+    {0, 0}};
+
+static const struct luaL_Reg optionsList[] = {
+    {"setOptions", set_options},
+    {"setHold", set_hold},
+    {"set20G", set_20g},
+    {"setBag", set_bag7},
+    {"setPCLoop", set_pcloop},
+    {"setNode", set_max_nodes},
+    {0, 0}};
+
+static const struct luaL_Reg weightsList[] = {
+    {"setWeights", set_weights},
+    {"fastWeights", fast_weights},
     {0, 0}};
 
 int luaopen_CCloader(lua_State *L) {
+    luaL_newmetatable(L, "CCOptions");
+    lua_pushstring(L, "__index");  // see comments below
+    lua_pushvalue(L, -2);
+    lua_settable(L, -3);
+    luaL_register(L, 0, optionsList);
+    luaL_newmetatable(L, "CCWeights");
+    lua_pushstring(L, "__index");  // see comments below
+    lua_pushvalue(L, -2);
+    lua_settable(L, -3);
+    luaL_register(L, 0, weightsList);
+    luaL_newmetatable(L, "CCBot");
+    lua_pushstring(L, "__index");
+    lua_pushvalue(L, -2);  /* pushes the metatable again */
+    lua_settable(L, -3);  /* metatable.__index = metatable */
+    luaL_register(L, 0, methList);  /* registers methList into the metatable */
+    // we don't need to return these metatables, because the corresponding objects
+    // will automatically have those metatables set.
     luaL_register(L, "cc", funcList);
     return 1;
 }

--- a/cold_clear_wrapper.c
+++ b/cold_clear_wrapper.c
@@ -51,7 +51,7 @@ static int reset_async(lua_State *L) {
     bool b2b = lua_toboolean(L, 3);
     int combo = lua_tointeger(L, 4);
     bool field[400];
-    int size = luaL_getn(L, 1);
+    int size = luaL_getn(L, 2);
     for (int i = 1; i <= size; i++) {
         lua_rawgeti(L, 2, i);
         field[i] = lua_toboolean(L, -1);

--- a/cold_clear_wrapper.c
+++ b/cold_clear_wrapper.c
@@ -9,7 +9,7 @@
 
 // #define DEBUG_CC
 #ifdef DEBUG_CC
-static void* check_userdata(lua_State *L, int index, const char *tname) {
+static void *check_userdata(lua_State *L, int index, const char *tname) {
     void *ud = luaL_checkudata(L, index, tname);
     luaL_argcheck(L, ud != NULL, index, tname);
     return ud;
@@ -18,10 +18,10 @@ static void* check_userdata(lua_State *L, int index, const char *tname) {
 #define lua_tostring luaL_checkstring
 #define lua_tonumber luaL_checknumber
 #else  /* DEBUG_CC */
-static void* check_userdata(lua_State *L, int index, const char *tname) {
+static void *check_userdata(lua_State *L, int index, const char *tname) {
     return lua_touserdata(L, index);
 }
-#endif  /* DEBUG_CC */
+#endif /* DEBUG_CC */
 
 //CCAsyncBot *cc_launch_async(CCOptions *options, CCWeights *weights);
 static int launch_async(lua_State *L) {
@@ -52,7 +52,7 @@ static int reset_async(lua_State *L) {
     int combo = lua_tointeger(L, 4);
     bool field[400];
     int size = luaL_getn(L, 1);
-    for (int i=1; i<=size; i++) {
+    for (int i = 1; i <= size; i++) {
         lua_rawgeti(L, 2, i);
         field[i] = lua_toboolean(L, -1);
         lua_pop(L, 1);
@@ -66,7 +66,7 @@ static int reset_async(lua_State *L) {
 static int add_next_piece_async(lua_State *L) {
     CCAsyncBot *bot = *(CCAsyncBot **)check_userdata(L, 1, "CCBot");
     int piece = lua_tointeger(L, 2);
-    cc_add_next_piece_async(bot, 7-piece);
+    cc_add_next_piece_async(bot, 7 - piece);
     return 0;
 }
 
@@ -344,9 +344,9 @@ int luaopen_CCloader(lua_State *L) {
     luaL_register(L, 0, weightsList);
     luaL_newmetatable(L, "CCBot");
     lua_pushstring(L, "__index");
-    lua_pushvalue(L, -2);  /* pushes the metatable again */
-    lua_settable(L, -3);  /* metatable.__index = metatable */
-    luaL_register(L, 0, methList);  /* registers methList into the metatable */
+    lua_pushvalue(L, -2);          /* pushes the metatable again */
+    lua_settable(L, -3);           /* metatable.__index = metatable */
+    luaL_register(L, 0, methList); /* registers methList into the metatable */
     // we don't need to return these metatables, because the corresponding objects
     // will automatically have those metatables set.
     luaL_register(L, "cc", funcList);

--- a/cold_clear_wrapper.c
+++ b/cold_clear_wrapper.c
@@ -294,7 +294,7 @@ static int set_weights(lua_State *L) {
 }
 
 static int about(lua_State *L) {
-    lua_pushstring(L, "wrapper by flaribbit");
+    lua_pushstring(L, "wrapper by 26F-Studio");
     return 1;
 }
 

--- a/cold_clear_wrapper.c
+++ b/cold_clear_wrapper.c
@@ -303,8 +303,6 @@ Changing these is as easy as a Find+Replace, so I'm not deciding for now. */
 static const struct luaL_Reg funcList[] = {
     {"about", about},
     {"launchAsync", launch_async},
-    {"defaultOptions", default_options},
-    {"defaultWeights", default_weights},
     {"getDefaultConfig", get_default_config},
     {0, 0}};
 
@@ -318,6 +316,7 @@ static const struct luaL_Reg methList[] = {
     {0, 0}};
 
 static const struct luaL_Reg optionsList[] = {
+    {"defaultOptions", default_options},
     {"setOptions", set_options},
     {"setHold", set_hold},
     {"set20G", set_20g},
@@ -327,6 +326,7 @@ static const struct luaL_Reg optionsList[] = {
     {0, 0}};
 
 static const struct luaL_Reg weightsList[] = {
+    {"defaultWeights", default_weights},
     {"setWeights", set_weights},
     {"fastWeights", fast_weights},
     {0, 0}};


### PR DESCRIPTION
- 将CCBot、CCOptions、CCWeights从light userdata改为full userdata，使用lua自己的gc系统。并将大多数API改为面向对象式，允许`bot:think()`等用法（等价于`bot.think(bot)`，等价于之前的版本中的`cc.think(bot)`）。
- 修改了绝大多数因为lua的动态类型而有可能segfault的地方，在定义了DEBUG macro的时候先检查类型，默认关闭。
- 修改了lua函数的命名规范，使用驼峰，目前采用的是Techmino中MrZ钦定的名字。